### PR TITLE
Bump black version to fix click compatiblity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==22.1.0
+black==22.3.0
 coverage==6.3.1
 coveralls==3.3.1
 pylint==2.12.2


### PR DESCRIPTION
For details see: https://stackoverflow.com/questions/71673404/importerror-cannot-import-name-unicodefun-from-click
Black package versions <22.3.0 are not compatible with click 8.1.0